### PR TITLE
Remove New badge from Digital Assets link

### DIFF
--- a/index.html
+++ b/index.html
@@ -522,7 +522,6 @@
             <a href="#" class="nav-item" data-section="digital-assets">
                 <div class="nav-item-icon">💎</div>
                 Digital Assets
-                <span class="nav-item-badge">New</span>
             </a>
             <a href="#" class="nav-item" data-section="settings">
                 <div class="nav-item-icon">⚙️</div>


### PR DESCRIPTION
## Summary
- delete the `New` badge from the Digital Assets navigation entry

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842ebc030988323b742a321a9e4a7ca