### PR TITLE
Auto-refresh cryptocurrency prices

### DIFF
--- a/index.html
+++ b/index.html
@@ -739,9 +739,6 @@
                     <h2 class="section-title">Digital Assets</h2>
                     <p class="section-subtitle">Cryptocurrency performance and NFT portfolio</p>
                 </div>
-                <button onclick="loadCryptoData()" style="background: #1976d2; color: white; border: none; padding: 8px 15px; border-radius: 4px; cursor: pointer;">
-                    🔄 Refresh Prices
-                </button>
             </div>
 
             <div style="margin-bottom: 30px;">
@@ -944,13 +941,15 @@
             loadNewsData();
             loadCryptoData();
             
-            // Auto-refresh data every 5 minutes
+            // Auto-refresh economic and weather data every 5 minutes
             setInterval(() => {
                 loadEconomicData();
                 loadWeatherData();
-                loadCryptoData();
             }, 5 * 60 * 1000);
-            
+
+            // Auto-refresh crypto prices every 10 minutes
+            setInterval(loadCryptoData, 10 * 60 * 1000);
+
             // Auto-refresh news every 15 minutes
             setInterval(loadNewsData, 15 * 60 * 1000);
         });


### PR DESCRIPTION
## Summary
- remove manual refresh button from Digital Assets section
- refresh cryptocurrency prices automatically every 10 minutes

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6842ef3216208323b11f4db949f5d170