### PR TITLE
Fix economy header

### DIFF
--- a/index.html
+++ b/index.html
@@ -514,8 +514,7 @@
         <div class="content-section active" id="economy">
             <div class="section-header">
                 <div>
-                    <h2 class="section-title">Ray Dalio's Economic Dashboard</h2>
-                    <p class="section-subtitle">Key indicators for economic stability and crisis prediction</p>
+                    <h2 class="section-title">Key indicators for economic stability and crisis prediction</h2>
                 </div>
                 <div id="lastUpdated" style="color: #666; font-size: 0.8rem;">Loading...</div>
             </div>


### PR DESCRIPTION
## Summary
- update the Economy section header text
- remove the redundant subtitle line under the Economy section

## Testing
- `git diff --color | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6842f6697b04832381250439367f2a48