### PR TITLE
Fix World Mobile stats fetch url

### DIFF
--- a/index.html
+++ b/index.html
@@ -1917,7 +1917,7 @@
         }
         async function loadWorldMobileStats() {
             try {
-                const response = await fetch("https://explorer.worldmobile.io/api/v1/stats");
+                const response = await fetch(CORS_PROXY + encodeURIComponent('https://explorer.worldmobile.io/api/v1/stats'));
                 const data = await response.json();
                 if (data) {
                     const totalTxEl = document.getElementById("wm-total-txns");


### PR DESCRIPTION
## Summary
- call World Mobile stats API through the existing CORS proxy to avoid CORS errors

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68430d93f5e88323a8f651b6d06fa8f5