### PR TITLE
Add sports section with scores

### DIFF
--- a/index.html
+++ b/index.html
@@ -547,6 +547,10 @@
                 <div class="nav-item-icon">📰</div>
                 News
             </a>
+            <a href="#" class="nav-item" data-section="sports">
+                <div class="nav-item-icon">🏟️</div>
+                Sports
+            </a>
             <a href="#" class="nav-item" data-section="climate">
                 <div class="nav-item-icon">🌡️</div>
                 Climate
@@ -1063,7 +1067,7 @@
             <div class="section-header">
                 <div>
                     <h2 class="section-title">Latest News</h2>
-                    <p class="section-subtitle">Top 5 headlines from World, US, World Sports, Costa Rica, and Costa Rica Sports</p>
+                    <p class="section-subtitle">Top 5 headlines from World, US, and Costa Rica</p>
                         <div id="news-refresh-info" style="color: #666; font-size: 0.8rem;">Automatically updated every 10 minutes</div>
                 </div>
                 
@@ -1103,22 +1107,6 @@
                 </div>
             </div>
 
-            <!-- World Sports News -->
-            <div style="margin-bottom: 30px;">
-                <h3 style="margin-bottom: 15px; color: #2c3e50; display: flex; align-items: center; gap: 10px;">
-                    🏅 World Sports News
-                </h3>
-                <div class="news-grid" id="world-sports-news-container">
-                    <div class="news-card">
-                        <div class="news-image"></div>
-                        <div class="news-content">
-                            <h3>Loading world sports news...</h3>
-                            <p>Please wait while we fetch the latest sports headlines.</p>
-                            <div class="news-meta">Loading...</div>
-                        </div>
-                    </div>
-                </div>
-            </div>
 
             <!-- Costa Rica News -->
             <div style="margin-bottom: 30px;">
@@ -1131,6 +1119,34 @@
                         <div class="news-content">
                             <h3>Loading Costa Rica news...</h3>
                             <p>Please wait while we fetch the latest local headlines.</p>
+                            <div class="news-meta">Loading...</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+        </div>
+
+        <!-- Sports Section -->
+        <div class="content-section" id="sports">
+            <div class="section-header">
+                <div>
+                    <h2 class="section-title">Sports Updates</h2>
+                    <p class="section-subtitle">Top sports headlines and today's scores</p>
+                </div>
+            </div>
+
+            <!-- World Sports News -->
+            <div style="margin-bottom: 30px;">
+                <h3 style="margin-bottom: 15px; color: #2c3e50; display: flex; align-items: center; gap: 10px;">
+                    🏅 World Sports News
+                </h3>
+                <div class="news-grid" id="world-sports-news-container">
+                    <div class="news-card">
+                        <div class="news-image"></div>
+                        <div class="news-content">
+                            <h3>Loading world sports news...</h3>
+                            <p>Please wait while we fetch the latest sports headlines.</p>
                             <div class="news-meta">Loading...</div>
                         </div>
                     </div>
@@ -1152,6 +1168,13 @@
                         </div>
                     </div>
                 </div>
+            </div>
+
+            <div style="margin-bottom: 30px;">
+                <h3 style="margin-bottom: 15px; color: #2c3e50; display: flex; align-items: center; gap: 10px;">
+                    📅 Today's Matches
+                </h3>
+                <div id="sports-scores-container">Loading matches...</div>
             </div>
         </div>
 
@@ -1393,6 +1416,7 @@
             loadEconomicData();
             loadWeatherData();
             loadNewsData();
+            loadSportsScores();
             loadCryptoData();
             
             loadWorldMobileStats();
@@ -1402,10 +1426,12 @@
                 loadWeatherData();
                 loadCryptoData();
                 loadWorldMobileStats();
+                loadSportsScores();
             }, 5 * 60 * 1000);
-            
+
             // Auto-refresh news every 10 minutes
             setInterval(loadNewsData, 10 * 60 * 1000);
+            setInterval(loadSportsScores, 10 * 60 * 1000);
         });
 
         // Economic data (keeping existing functionality)
@@ -1951,7 +1977,7 @@
                 }
             }
         }
-        async function loadWorldMobileStats() {
+async function loadWorldMobileStats() {
             try {
                 const response = await fetch(CORS_PROXY + encodeURIComponent('https://explorer.worldmobile.io/api/v1/stats'));
                 const data = await response.json();
@@ -1972,8 +1998,39 @@
                 if (totalAddrEl) totalAddrEl.textContent = fallback.totalAddresses.toLocaleString();
                 const dailyEl = document.getElementById("wm-daily-txns");
                 if (dailyEl) dailyEl.textContent = fallback.dailyTransactions.toLocaleString();
-            }
         }
+    }
+
+    async function loadSportsScores() {
+        try {
+            const response = await fetch('https://raw.githubusercontent.com/openfootball/football.json/master/2024-25/en.1.json');
+            const data = await response.json();
+            const today = new Date().toISOString().split('T')[0];
+            const matches = (data.matches || []).filter(m => m.date === today);
+            const container = document.getElementById('sports-scores-container');
+            container.innerHTML = '';
+            if (!matches.length) {
+                container.textContent = 'No matches today';
+                return;
+            }
+            matches.slice(0,5).forEach(match => {
+                const div = document.createElement('div');
+                div.className = 'news-card';
+                const score = match.score && match.score.ft ? match.score.ft.join(' - ') : 'vs';
+                div.innerHTML = `
+                    <div class="news-content">
+                        <h3>${match.team1} ${score} ${match.team2}</h3>
+                        <div class="news-meta">${match.round}</div>
+                    </div>
+                `;
+                container.appendChild(div);
+            });
+        } catch (e) {
+            const container = document.getElementById('sports-scores-container');
+            if (container) container.textContent = 'Error loading matches';
+            console.error('Error loading sports scores:', e);
+        }
+    }
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a new Sports page section
- move sports headlines out of News
- update navigation to include Sports
- fetch match data from openfootball

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6843107300e883238d6eca73892b1a81