### PR TITLE
Fix date handling in sports scores

### DIFF
--- a/index.html
+++ b/index.html
@@ -2010,7 +2010,8 @@ async function loadWorldMobileStats() {
             { url: 'https://raw.githubusercontent.com/openfootball/football.json/master/2024-25/fr.1.json', name: 'Ligue 1' },
             { url: 'https://raw.githubusercontent.com/openfootball/football.json/master/2024-25/uefa.cl.json', name: 'Champions League' }
         ];
-        const today = new Date().toISOString().split('T')[0];
+        // Use the user's local timezone when comparing match dates
+        const today = new Date().toLocaleDateString('en-CA');
         const container = document.getElementById('sports-scores-container');
         container.innerHTML = '';
         let found = false;


### PR DESCRIPTION
## Summary
- use the user's local date when filtering today's matches

## Testing
- `node -e "console.log(new Date().toLocaleDateString('en-CA'));"`

------
https://chatgpt.com/codex/tasks/task_e_6843150f3d60832384d2f29f4d603da8