### PR TITLE
Replace API key placeholder and document setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Dashboard
+
+This project contains a simple analytics dashboard that pulls economic data from the [FRED](https://fred.stlouisfed.org/) API along with other informational widgets.
+
+## Setup
+
+To fetch data from FRED, the application requires a FRED API key. The key is referenced in `index.html` via the `FRED_API_KEY` constant:
+
+```javascript
+const FRED_API_KEY = '<YOUR_FRED_KEY>'; // replace with your key
+```
+
+Provide your key in one of the following ways:
+
+1. **Manual edit** – replace `<YOUR_FRED_KEY>` in `index.html` with your actual key.
+2. **Environment variable** – set an environment variable named `FRED_API_KEY` and inject it into `index.html` during your build or deploy process.
+
+If you use an automated build, create a script that reads `FRED_API_KEY` from the environment and replaces the placeholder before serving the page.
+
+## Running
+
+The dashboard is a static site. Simply open `index.html` in your browser or serve it via any static file server.

--- a/index.html
+++ b/index.html
@@ -1438,7 +1438,8 @@
         });
 
         // Economic data (keeping existing functionality)
-        const FRED_API_KEY = '4aba315f03e5658a7ae6a8083473f44b';
+        // Insert your FRED API key below or configure it via environment during build
+        const FRED_API_KEY = '<YOUR_FRED_KEY>';
         const CORS_PROXY = 'https://api.allorigins.win/raw?url=';
         const FRED_BASE_URL = 'https://api.stlouisfed.org/fred/series/observations';
 


### PR DESCRIPTION
## Summary
- remove the hard-coded FRED API key
- add setup instructions for configuring `FRED_API_KEY`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68431519049083238f45bb2d8b9910c7