### PR TITLE
Fix external link security attributes

### DIFF
--- a/index.html
+++ b/index.html
@@ -975,7 +975,7 @@
                     <p class="section-subtitle">Environmental data for your location (Costa Rica) and global climate metrics</p>
                 </div>
                 <div>
-                    <a href="https://www.windy.com/-Rain-thunder-rain?rain,9.865,-84.413,9" target="_blank" 
+                    <a href="https://www.windy.com/-Rain-thunder-rain?rain,9.865,-84.413,9" target="_blank" rel="noopener noreferrer"
                        style="color: #1976d2; text-decoration: none; font-size: 0.85rem;">
                        📍 View on Windy.com
                     </a>
@@ -1855,7 +1855,7 @@
                 newsCard.className = 'news-card';
                 newsCard.innerHTML = `
                     <div class="news-content">
-                        <h3><a href="${article.link}" target="_blank">${article.title}</a></h3>
+                        <h3><a href="${article.link}" target="_blank" rel="noopener noreferrer">${article.title}</a></h3>
                         <p>${article.summary}</p>
                         <div class="news-meta">${article.time}</div>
                     </div>


### PR DESCRIPTION
## Summary
- update the Windy.com link to use `rel="noopener noreferrer"`
- add the same security attributes in `updateNewsSection`

## Testing
- `grep -R "target=\"_blank\"" -n .`

------
https://chatgpt.com/codex/tasks/task_e_684315286a388323ba927be805c7e482