### PR TITLE
Remove stray tagline and fix Minutes Network section

### DIFF
--- a/index.html
+++ b/index.html
@@ -530,7 +530,6 @@
     <div class="sidebar">
         <div class="sidebar-header">
             <div class="logo">AHD Dash</div>
-            <p style="color: #666; font-size: 0.8rem;">Comprehensive Analytics</p>
         </div>
 
         <!--
@@ -1301,7 +1300,6 @@
                     </div>
                 </div>
             </div>
-        </div>
         
         <div style="margin-bottom: 30px;">
             <h3 style="margin-bottom: 15px; color: #2c3e50;">🛰️ Minutes Network</h3>
@@ -1340,6 +1338,7 @@
                     <div class="metric-value" id="mn-daily-txns">Loading...</div>
                 </div>
             </div>
+        </div>
         </div>
 
         <!-- Settings Section -->


### PR DESCRIPTION
## Summary
- remove sidebar tagline under **AHD Dash**
- keep **Minutes Network** inside the Digital Assets section so it doesn't show on other pages

## Testing
- `pre-commit` *(fails: no configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6843172aab6883238a11b02d79a8259a