### PR TITLE
Add offline crypto fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -2012,24 +2012,97 @@
                 }
             } catch (error) {
                 console.error('Error loading crypto data:', error);
-                Object.keys(coinMap).forEach(key => {
+                const fallbackData = {
+                    'bitcoin': {
+                        current_price: 67500,
+                        price_change_percentage_24h_in_currency: 1.2,
+                        price_change_percentage_30d_in_currency: 5.3,
+                        price_change_percentage_1y_in_currency: 122.1,
+                        total_volume: 25000000000,
+                        market_cap_rank: 1
+                    },
+                    'ethereum': {
+                        current_price: 3500,
+                        price_change_percentage_24h_in_currency: 1.8,
+                        price_change_percentage_30d_in_currency: 7.2,
+                        price_change_percentage_1y_in_currency: 95.5,
+                        total_volume: 15000000000,
+                        market_cap_rank: 2
+                    },
+                    'cardano': {
+                        current_price: 0.45,
+                        price_change_percentage_24h_in_currency: 0.9,
+                        price_change_percentage_30d_in_currency: 4.1,
+                        price_change_percentage_1y_in_currency: 40.2,
+                        total_volume: 750000000,
+                        market_cap_rank: 8
+                    },
+                    'world-mobile-token': {
+                        current_price: 0.16,
+                        price_change_percentage_24h_in_currency: 2.1,
+                        price_change_percentage_30d_in_currency: 9.8,
+                        price_change_percentage_1y_in_currency: 26.5,
+                        total_volume: 10000000,
+                        market_cap_rank: 450
+                    },
+                    'minutes-network': {
+                        current_price: 0.06,
+                        price_change_percentage_24h_in_currency: 0.5,
+                        price_change_percentage_30d_in_currency: 2.5,
+                        price_change_percentage_1y_in_currency: 12.0,
+                        total_volume: 3000000,
+                        market_cap_rank: 1400
+                    }
+                };
+
+                Object.entries(coinMap).forEach(([key, id]) => {
+                    const coin = fallbackData[id];
                     const priceEl = document.getElementById(`${key}-price`);
                     if (priceEl) {
-                        priceEl.textContent = 'N/A';
+                        if (coin && typeof coin.current_price === 'number') {
+                            const price = coin.current_price;
+                            if (key === 'wmtx' || key === 'mntx') {
+                                priceEl.textContent = price.toFixed(4);
+                            } else {
+                                priceEl.textContent = price.toLocaleString();
+                            }
+                        } else {
+                            priceEl.textContent = 'N/A';
+                        }
                         priceEl.classList.remove('loading');
                     }
-                    ['24h','30d','ytd'].forEach(period => {
+
+                    const changes = {
+                        '24h': coin.price_change_percentage_24h_in_currency,
+                        '30d': coin.price_change_percentage_30d_in_currency,
+                        'ytd': coin.price_change_percentage_1y_in_currency
+                    };
+
+                    Object.keys(changes).forEach(period => {
+                        const value = changes[period];
                         const changeEl = document.getElementById(`${key}-${period}`);
                         if (changeEl) {
-                            changeEl.textContent = `${period}: N/A`;
-                            changeEl.className = 'metric-change neutral';
+                            if (typeof value === 'number') {
+                                const trend = value > 0 ? 'positive' : value < 0 ? 'negative' : 'neutral';
+                                changeEl.textContent = `${period}: ${formatChange(value, trend)}`;
+                                changeEl.className = `metric-change ${trend}`;
+                            } else {
+                                changeEl.textContent = `${period}: N/A`;
+                                changeEl.className = 'metric-change neutral';
+                            }
                         }
                     });
+
+                    if (key === 'wmtx' || key === 'mntx') {
+                        const volEl = document.getElementById(`${key}-volume`);
+                        if (volEl) volEl.textContent = coin.total_volume.toLocaleString();
+                        const rankEl = document.getElementById(`${key}-rank`);
+                        if (rankEl) rankEl.textContent = `#${coin.market_cap_rank}`;
+                    }
                 });
                 const cryptoUpdateEl = document.getElementById('cryptoLastUpdated');
                 if (cryptoUpdateEl) {
-
-                    cryptoUpdateEl.innerHTML = '<span style="color: #f44336;">Error loading data</span>';
+                    cryptoUpdateEl.textContent = 'Last updated: offline data';
                 }
             }
         }


### PR DESCRIPTION
## Summary
- provide fallback crypto data when CoinGecko API is unreachable

## Testing
- `ls`

------
https://chatgpt.com/codex/tasks/task_e_684316fb41b88323a4da8c083f0961d7