### PR TITLE
Add TheSportsDB key instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,20 @@ Provide your key in one of the following ways:
 
 If you use an automated build, create a script that reads `FRED_API_KEY` from the environment and replaces the placeholder before serving the page.
 
+### Sports API Key
+
+The page also pulls live scores using TheSportsDB. In `index.html` you'll see
+the following placeholder:
+
+```javascript
+const SPORTS_API_KEY = '123';
+```
+
+Replace `'123'` with your own API key from
+[TheSportsDB](https://www.thesportsdb.com/api.php). As with the FRED key, you
+can manually edit the file or set an environment variable named
+`SPORTS_API_KEY` and inject it during your build process.
+
 
 ## Running
 


### PR DESCRIPTION
## Summary
- document how to configure `SPORTS_API_KEY`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684334b1731c8323a07bdb2cd06e682d